### PR TITLE
fix(hookChallenge): :bug: add validation to empty bundles

### DIFF
--- a/src/hooks/useGetChallenges.ts
+++ b/src/hooks/useGetChallenges.ts
@@ -18,10 +18,19 @@ const useGetChallenges = () => {
                         },
                     }
                 );
+
+                if (response.data.bundles.length === 0) {
+                    setError("No challenges found.");
+                    setLoading(false);
+                    
+                    return;
+                }
+
                 const data = response.data.bundles[0].bundles;
                 setChallenges(data);
                 setLoading(false)
             } catch (error) {
+                console.log('Error:', error);
                 setError("Something went wrong. Please try again later.");
                 setLoading(false);
             }


### PR DESCRIPTION
This pull request includes a small change to the `useGetChallenges` hook in the `src/hooks/useGetChallenges.ts` file. The change adds error handling for cases where no challenges are found in the response data.

* [`src/hooks/useGetChallenges.ts`](diffhunk://#diff-a0f603d2f22785953cef67862715be90a0633fe8e4b318b22c726a66455b2aa5R21-R33): Added a check for an empty `bundles` array in the response data, setting an error message and stopping the loading state if no challenges are found. Also added a console log for errors.